### PR TITLE
Per monitor scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,24 @@ var image = Screenshot.CaptureRegion(rect);
 // get a screenshot of all screens
 var image = Screenshot.CaptureAllScreens();
 ```
+
+## Multiple monitors with different scale factors
+
+The application must enable **per-monitor DPI awareness** in order for the region selection to work properly on a multi-monitor setup where not all monitors use the same scale factor.
+
+It is recommended that to be [set in the application manifest](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/mt846517(v%3Dvs.85)#setting-default-awareness-with-the-application-manifest):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+
+</assembly>
+```

--- a/ScreenshotDemo/ScreenshotDemo.csproj
+++ b/ScreenshotDemo/ScreenshotDemo.csproj
@@ -34,6 +34,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -87,6 +90,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/ScreenshotDemo/app.manifest
+++ b/ScreenshotDemo/app.manifest
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+
+</assembly>


### PR DESCRIPTION
Added an application manifest file that enables per-monitor DPI setting in the demo application. This is required for the region selection to work properly in multi-monitor scenario where not all monitors have the same scale factor.

Closes #2